### PR TITLE
Add file import for posts

### DIFF
--- a/app/Filament/Actions/ImportFilesAction.php
+++ b/app/Filament/Actions/ImportFilesAction.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Filament\Actions;
+
+use App\Models\Category;
+use App\Services\FileImportService;
+use Filament\Actions\Action;
+use Filament\Forms\Components\FileUpload;
+use Filament\Forms\Components\Select;
+use Filament\Notifications\Notification;
+use Illuminate\Http\UploadedFile;
+
+class ImportFilesAction
+{
+    public static function make(?Category $category = null): Action
+    {
+        return Action::make('import')
+            ->label(__('Import files'))
+            ->icon('heroicon-o-arrow-up-tray')
+            ->color('gray')
+            ->visible(fn (): bool => auth()->check())
+            ->authorize(fn (): bool => auth()->check())
+            ->form([
+                Select::make('category_id')
+                    ->label(__('Category'))
+                    ->required()
+                    ->default($category?->id)
+                    ->options(fn (): array => Category::getSelectOptions())
+                    ->searchable()
+                    ->preload(),
+                FileUpload::make('files')
+                    ->label(__('Files'))
+                    ->multiple()
+                    ->storeFiles(false)
+                    ->acceptedFileTypes(['application/zip', 'application/x-zip-compressed', 'text/markdown', 'text/x-markdown', 'text/plain', 'text/html'])
+                    ->rules(['extensions:zip,md'])
+                    ->helperText(__('.zip or .md files only.'))
+                    ->required(),
+            ])
+            ->action(function (array $data): void {
+                $importer = new FileImportService;
+                $categoryId = $data['category_id'];
+
+                foreach ($data['files'] as $file) {
+                    if (! $file instanceof UploadedFile || ! $file->getRealPath()) {
+                        continue;
+                    }
+
+                    $path = $file->getRealPath();
+                    $extension = strtolower($file->getClientOriginalExtension());
+
+                    if ($extension === 'zip') {
+                        $importer->fromZip($path, $categoryId);
+
+                        continue;
+                    }
+
+                    if ($extension === 'md') {
+                        $importer->fromFiles([$path], $categoryId, $file->getClientOriginalName());
+                    }
+                }
+
+                Notification::make()
+                    ->title(__('Import complete'))
+                    ->body(__(':count post(s) imported.', ['count' => $importer->created]))
+                    ->success()
+                    ->send();
+
+                redirect(request()?->header('Referer'));
+            });
+    }
+}

--- a/app/Filament/Resources/Categories/Pages/ListCategories.php
+++ b/app/Filament/Resources/Categories/Pages/ListCategories.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\Categories\Pages;
 
+use App\Filament\Actions\ImportFilesAction;
 use App\Filament\Resources\Categories\CategoryResource;
 use Filament\Actions\CreateAction;
 use Filament\Resources\Pages\ListRecords;
@@ -13,6 +14,7 @@ class ListCategories extends ListRecords
     protected function getHeaderActions(): array
     {
         return [
+            ImportFilesAction::make(),
             CreateAction::make(),
         ];
     }

--- a/app/Filament/Resources/Categories/Pages/ViewCategory.php
+++ b/app/Filament/Resources/Categories/Pages/ViewCategory.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\Categories\Pages;
 
+use App\Filament\Actions\ImportFilesAction;
 use App\Filament\Resources\Categories\CategoryResource;
 use App\Filament\Resources\Posts\PostResource;
 use App\Models\Post;
@@ -17,6 +18,7 @@ class ViewCategory extends ViewRecord
     protected function getHeaderActions(): array
     {
         return [
+            ImportFilesAction::make($this->record),
             Action::make('create')
                 ->label(__('Create post'))
                 ->url(fn (): string => PostResource::getUrl('create', ['category_id' => $this->record->id]))

--- a/app/Filament/Resources/Posts/Pages/ListPosts.php
+++ b/app/Filament/Resources/Posts/Pages/ListPosts.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\Posts\Pages;
 
+use App\Filament\Actions\ImportFilesAction;
 use App\Filament\Resources\Posts\PostResource;
 use Filament\Actions\CreateAction;
 use Filament\Resources\Pages\ListRecords;
@@ -13,6 +14,7 @@ class ListPosts extends ListRecords
     protected function getHeaderActions(): array
     {
         return [
+            ImportFilesAction::make(),
             CreateAction::make(),
         ];
     }

--- a/app/Services/FileImportService.php
+++ b/app/Services/FileImportService.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace App\Services;
+
+use App\Enums\Visibility;
+use App\Models\Category;
+use App\Models\Post;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use ZipArchive;
+
+class FileImportService
+{
+    public int $created = 0;
+
+    public function fromFiles(array $paths, int $categoryId, ?string $name = null): void
+    {
+        foreach ($paths as $path) {
+            $this->importFile($path, $categoryId, name: $name);
+        }
+    }
+
+    public function fromZip(string $path, int $categoryId): void
+    {
+        $zip = new ZipArchive;
+
+        if ($zip->open($path) !== true) {
+            throw new \RuntimeException('Could not open ZIP file.');
+        }
+
+        $tmpDir = sys_get_temp_dir() . '/file-import-' . uniqid();
+        $zip->extractTo($tmpDir);
+        $zip->close();
+
+        try {
+            foreach ($this->markdownFiles($tmpDir) as $file) {
+                $relative = ltrim(str_replace($tmpDir, '', $file), '/\\');
+                $folder = dirname(str_replace('\\', '/', $relative));
+                $segments = $folder === '.' ? [] : explode('/', $folder);
+
+                // A zip can mirror a category tree, so folder segments become subcategories.
+                $this->importFile($file, $categoryId, $segments);
+            }
+        } finally {
+            File::deleteDirectory($tmpDir);
+        }
+    }
+
+    private function importFile(string $path, int $categoryId, array $subfolders = [], ?string $name = null): void
+    {
+        $content = trim(file_get_contents($path));
+
+        if ($content === '') {
+            return;
+        }
+
+        // Plain files stay in the selected category; zip folders drill deeper into the tree.
+        $categoryId = $subfolders === [] ? $categoryId : $this->resolveSubcategory($categoryId, $subfolders)->id;
+
+        $filename = pathinfo($name ?? $path, PATHINFO_FILENAME);
+
+        $post = new Post;
+        $post->title = Str::title(str_replace(['-', '_'], ' ', $filename));
+        $post->slug = $this->uniqueSlug(Str::slug($filename), $categoryId);
+        $post->category_id = $categoryId;
+        $post->content = $content;
+        $post->visibility = Visibility::Public;
+        $post->sort = 0;
+        $post->save();
+
+        $this->created++;
+    }
+
+    private function markdownFiles(string $dir): array
+    {
+        $files = [];
+
+        foreach (new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($dir, \RecursiveDirectoryIterator::SKIP_DOTS)) as $file) {
+            if (! $file->isFile() || $file->getExtension() !== 'md') {
+                continue;
+            }
+
+            // Work with the relative path so we can skip macOS metadata and hidden files reliably.
+            $relative = ltrim(str_replace($dir, '', $file->getPathname()), '/\\');
+
+            if (str_starts_with($relative, '__MACOSX/') || str_contains($relative, '/.') || str_starts_with($relative, '.')) {
+                continue;
+            }
+
+            $files[] = $file->getPathname();
+        }
+
+        sort($files);
+
+        return $files;
+    }
+
+    private function resolveSubcategory(int $parentId, array $segments): Category
+    {
+        $parent = Category::withoutGlobalScopes()->findOrFail($parentId);
+
+        // Walk through each folder segment and create missing subcategories.
+        foreach (array_filter($segments) as $segment) {
+            $name = Str::title(str_replace(['-', '_'], ' ', trim($segment)));
+            $slug = Str::slug($name);
+
+            $category = Category::withoutGlobalScopes()
+                ->where('parent_id', $parent->id)
+                ->where(fn ($query) => $query->where('name', $name)->orWhere('slug', $slug))
+                ->first();
+
+            if (! $category) {
+                // Missing folders in the archive become missing categories in Noton.
+                $category = new Category;
+                $category->name = $name;
+                $category->slug = $slug;
+                $category->parent_id = $parent->id;
+                $category->visibility = Visibility::Public;
+                $category->sort = 0;
+                $category->save();
+            }
+
+            $parent = $category;
+        }
+
+        return $parent;
+    }
+
+    private function uniqueSlug(string $base, int $categoryId): string
+    {
+        $slug = $base;
+        $suffix = 2;
+
+        // Add a number when the slug already exists in this category.
+        while (Post::withoutGlobalScopes()->where('category_id', $categoryId)->where('slug', $slug)->exists()) {
+            $slug = $base . '-' . $suffix++;
+        }
+
+        return $slug;
+    }
+}

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -1,4 +1,9 @@
 {
+    "Import files": "Bestanden importeren",
+    "Import complete": "Import voltooid",
+    ":count post(s) imported.": ":count bericht(en) geïmporteerd.",
+    ".zip or .md files only.": "Alleen .zip- of .md-bestanden.",
+    "Files": "Bestanden",
     "Admin": "Beheerder",
     "Categories": "Categorieën",
     "Category": "Categorie",

--- a/tests/Feature/FileImportServiceTest.php
+++ b/tests/Feature/FileImportServiceTest.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Filament\Actions\ImportFilesAction;
+use App\Filament\Resources\Posts\Pages\ListPosts;
+use App\Models\Category;
+use App\Models\Post;
+use App\Models\User;
+use App\Services\FileImportService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\File;
+use Livewire\Livewire;
+use Tests\TestCase;
+use ZipArchive;
+
+class FileImportServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_imports_markdown_files_into_the_selected_category(): void
+    {
+        $category = Category::factory()->create();
+        $directory = $this->makeTempDirectory();
+        $path = $directory . '/imported-post.md';
+
+        try {
+            file_put_contents($path, '# Hello' . "\n\n" . 'Imported content.');
+
+            $importer = new FileImportService;
+            $importer->fromFiles([$path], $category->id);
+
+            $post = Post::withoutGlobalScopes()->where('slug', 'imported-post')->first();
+
+            $this->assertSame(1, $importer->created);
+            $this->assertNotNull($post);
+            $this->assertSame($category->id, $post->category_id);
+            $this->assertSame('Imported Post', $post->title);
+            $this->assertStringContainsString('Imported content.', $post->content);
+        } finally {
+            File::deleteDirectory($directory);
+        }
+    }
+
+    public function test_it_imports_markdown_uploads_through_the_filament_action(): void
+    {
+        $category = Category::factory()->create();
+        $directory = $this->makeTempDirectory();
+        $path = $directory . '/imported-post.md';
+        $action = ImportFilesAction::make();
+
+        try {
+            file_put_contents($path, '# Hello' . "\n\n" . 'Imported content.');
+
+            $action->getActionFunction()([
+                'category_id' => $category->id,
+                'files' => [new UploadedFile($path, 'README.md', 'text/html', null, true)],
+            ]);
+
+            $post = Post::withoutGlobalScopes()
+                ->where('category_id', $category->id)
+                ->where('slug', 'readme')
+                ->first();
+
+            $this->assertNotNull($post);
+            $this->assertSame($category->id, $post->category_id);
+            $this->assertSame('Readme', $post->title);
+        } finally {
+            File::deleteDirectory($directory);
+        }
+    }
+
+    public function test_guests_cannot_see_the_import_action(): void
+    {
+        Livewire::test(ListPosts::class)
+            ->assertActionHidden('import');
+    }
+
+    public function test_logged_in_users_can_see_the_import_action(): void
+    {
+        $this->actingAs(User::factory()->create());
+
+        Livewire::test(ListPosts::class)
+            ->assertActionVisible('import');
+    }
+
+    public function test_it_imports_zip_subfolders_as_subcategories_under_the_selected_category(): void
+    {
+        $category = Category::factory()->create([
+            'name' => 'Docs',
+            'slug' => 'docs',
+        ]);
+
+        $zipPath = $this->makeZip([
+            'Guides/Setup/imported-post.md' => "# Hello\n\nImported content.",
+        ]);
+
+        try {
+            $importer = new FileImportService;
+            $importer->fromZip($zipPath, $category->id);
+
+            $post = Post::withoutGlobalScopes()->where('slug', 'imported-post')->first();
+            $subCategory = Category::withoutGlobalScopes()
+                ->where('parent_id', $category->id)
+                ->where('slug', 'guides')
+                ->first();
+            $nestedCategory = Category::withoutGlobalScopes()
+                ->where('parent_id', $subCategory?->id)
+                ->where('slug', 'setup')
+                ->first();
+
+            $this->assertSame(1, $importer->created);
+            $this->assertNotNull($subCategory);
+            $this->assertNotNull($nestedCategory);
+            $this->assertNotNull($post);
+            $this->assertSame($nestedCategory->id, $post->category_id);
+        } finally {
+            File::deleteDirectory(dirname($zipPath));
+        }
+    }
+
+    /**
+     * @param  array<string, string>  $files
+     */
+    private function makeZip(array $files): string
+    {
+        $path = $this->makeTempDirectory() . '/file-import.zip';
+        $zip = new ZipArchive;
+
+        $zip->open($path, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+
+        foreach ($files as $name => $contents) {
+            $zip->addFromString($name, $contents);
+        }
+
+        $zip->close();
+
+        return $path;
+    }
+
+    private function makeTempDirectory(): string
+    {
+        $directory = sys_get_temp_dir() . '/file-import-' . uniqid();
+        File::ensureDirectoryExists($directory);
+
+        return $directory;
+    }
+}


### PR DESCRIPTION
Adds a simple file import flow for posts so markdown files and zip archives can be imported directly into a selected category.

- imports one or more .md files into the chosen category
- imports .zip archives and turns folders into nested subcategories
- keeps the import flow available only for logged-in users and refreshes the sidebar after import

Fixes #11