### PR TITLE
chore: add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+## Summary
+
+<!-- One- or two-sentence description of the change. -->
+
+## Why
+
+<!-- What problem does this solve? Link any related issue: Fixes #123 -->
+
+## How tested
+
+<!-- Commands run, fixtures used, manual steps performed. -->
+- [ ]
+- [ ]
+
+## Screenshots
+
+<!-- Required for UI changes. -->
+
+## Checklist
+
+- [ ] `composer test` passes locally
+- [ ] `composer rector` (or `composer cs`) reports no new findings
+- [ ] No new dependencies introduced
+- [ ] Docs / `docs/setup.md` updated if behaviour or env vars changed


### PR DESCRIPTION
## Summary
- Add a short pull request template under `.github/pull_request_template.md` asking for a one-line summary, a 'why' line with an issue link, a 'how tested' checklist, and a screenshot section for UI changes.
- The closing checklist points new contributors at the project's existing local commands (`composer test`, `composer rector` / `composer cs`) so reviewers get consistent answers without having to dig into AGENTS.md.

## Why
The repository already has a CI workflow and a detailed AGENTS.md guide for AI contributors, but no PR template. New contributors vary widely in what they include, which makes review slower and forces maintainers to ask the same follow-up questions.

## How tested
- N/A (docs-only).
- Verified the file renders as a checklist template in a draft PR locally.
- No code paths or behaviours are changed.

## Checklist
- [x] No new dependencies
- [x] No env-var or behaviour changes
- [x] `docs/setup.md` not affected
