### PR TITLE
chore(github): add bug and feature issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,57 @@
+name: Bug Report
+description: Report a bug or unexpected behavior in Noton.
+title: "[bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. The information below helps us reproduce and fix it faster.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened
+      description: A clear, concise description of the bug.
+      placeholder: When I click "Save" on a draft post, the page reloads but the post is not saved.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected
+      description: What you expected to happen instead.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Numbered list of steps that trigger the bug.
+      placeholder: |
+        1. Log in as an admin
+        2. Go to Posts -> New
+        3. Fill in the title only
+        4. Click "Save"
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: |
+        Noton version, Docker image tag, `git rev-parse HEAD` if self-built.
+        PHP version, database (PostgreSQL/MySQL/SQLite), OS.
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Paste any `storage/logs/laravel.log` lines, browser console output, or container logs.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation
+    url: https://github.com/bartvantuijn/noton/blob/main/docs/setup.md
+    about: Setup guide and feature reference.
+  - name: Discussions
+    url: https://github.com/bartvantuijn/noton/discussions
+    about: Questions, ideas, and community support.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,41 @@
+name: Feature Request
+description: Suggest a new feature for Noton.
+title: "[feat] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Feature requests should describe a concrete use case. Open-ended "wouldn't it be cool if…" is best discussed on the Discussions tab.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem are you trying to solve? Who else hits it?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: How would you like this to work? Mock-ups, sketches, or references welcome.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you have ruled out and why.
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Anything else that helps frame the request.
+    validations:
+      required: false


### PR DESCRIPTION
## What

Adds .github/ISSUE_TEMPLATE/bug.yml and feature.yml so contributors get a consistent set of prompts (summary, repro, environment) and the right labels are applied automatically. Disables blank issues and points users at the docs and Discussions tab via config.yml.

## Why

The repo has a PR template and CI but no issue templates, so bugs are filed as free-form text and get missed or stuck in triage. A small, predictable form (steps to reproduce, environment, logs) cuts the back-and-forth on most reports.

## Notes

- The new templates follow the GitHub forms syntax (`blank_issues_enabled: false` in config.yml) used by the wider Laravel/Filament ecosystem.
- No code or behaviour changes.