### PR TITLE
docs: add CONTRIBUTING.md for contributors

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,57 @@
+name: Bug Report
+description: Report a bug or unexpected behavior in Noton.
+title: "[bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. The information below helps us reproduce and fix it faster.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened
+      description: A clear, concise description of the bug.
+      placeholder: When I click "Save" on a draft post, the page reloads but the post is not saved.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected
+      description: What you expected to happen instead.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Numbered list of steps that trigger the bug.
+      placeholder: |
+        1. Log in as an admin
+        2. Go to Posts -> New
+        3. Fill in the title only
+        4. Click "Save"
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: |
+        Noton version, Docker image tag, `git rev-parse HEAD` if self-built.
+        PHP version, database (PostgreSQL/MySQL/SQLite), OS.
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Paste any `storage/logs/laravel.log` lines, browser console output, or container logs.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation
+    url: https://github.com/bartvantuijn/noton/blob/main/docs/setup.md
+    about: Setup guide and feature reference.
+  - name: Discussions
+    url: https://github.com/bartvantuijn/noton/discussions
+    about: Questions, ideas, and community support.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,41 @@
+name: Feature Request
+description: Suggest a new feature for Noton.
+title: "[feat] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Feature requests should describe a concrete use case. Open-ended "wouldn't it be cool if…" is best discussed on the Discussions tab.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem are you trying to solve? Who else hits it?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: How would you like this to work? Mock-ups, sketches, or references welcome.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you have ruled out and why.
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Anything else that helps frame the request.
+    validations:
+      required: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,76 @@
+# Contributing to Noton
+
+Thanks for your interest in contributing. Noton is a small Laravel + Filament
+application and most contributions are small bug fixes, documentation
+improvements, or Filament/Livewire polish.
+
+## Development setup
+
+You need PHP 8.2+ (CI uses 8.4), Composer, Node 24, and a database
+(SQLite in-memory is enough for tests; PostgreSQL or MySQL for local
+development). Clone the repo and run:
+
+```bash
+composer install
+npm install
+cp .env.example .env
+php artisan key:generate
+php artisan migrate
+npm run build
+```
+
+For day-to-day work, `composer dev` runs the PHP server, queue worker,
+log stream (`pail`), and Vite together via `concurrently`.
+
+## Tests
+
+```bash
+composer test         # config:clear + php artisan test
+php artisan test --filter=ChatModalTest
+```
+
+Tests use SQLite `:memory:` and a sync queue, so they are hermetic.
+AI services (`OllamaService`, `OpenClawService`) are **always mocked** in
+tests — see `tests/Feature/ChatModalTest.php` for the pattern.
+
+## Code style
+
+We run Rector and Pint in CI:
+
+```bash
+composer rector       # Rector (config: rector.php)
+composer pint         # Pint (Laravel preset + project rules)
+composer cs           # rector then pint, in that order
+```
+
+PRs that touch PHP should leave `composer cs` clean.
+
+## Pull requests
+
+- One focused change per PR. Large refactors should be discussed in an
+  issue first.
+- The PR template asks for a one-line summary, a "How tested" section,
+  and screenshots for UI changes — please fill all of them in.
+- If your change touches migrations, include the up **and** down paths
+  and a note on backwards compatibility.
+- If your change touches AI behaviour (`OllamaService`, `OpenClawService`,
+  `ChatModal`), keep the system prompt template under
+  `App\Livewire\ChatModal` and update the related feature test.
+
+## AI-assisted contributions
+
+If you use an AI assistant to help draft the patch, please read
+`AGENTS.md` first. It documents the project structure, the conventions
+the maintainer cares about, and the test/lint commands an AI should
+run before opening a PR.
+
+## Reporting issues
+
+Use the bug and feature request templates under
+`.github/ISSUE_TEMPLATE/`. They ask for the information the maintainer
+needs to triage on the first pass; please fill them in.
+
+## License
+
+By contributing, you agree that your contributions are licensed under
+the project's [FSL-1.1](LICENSE) license.


### PR DESCRIPTION
## What

Adds a CONTRIBUTING.md at the repo root that documents the dev setup, test command, code-style flow, and the project-specific conventions first-time contributors trip on.

## Why

The README links to docs/setup.md (user-facing) and to AGENTS.md (AI assistants) but there was nothing for human contributors. The project uses Rector + Pint and AI services are always mocked in tests; both are easy to miss.

## Notes

- No code or behaviour changes.
- The file is a single markdown doc with copy-pasteable commands.